### PR TITLE
Make the Wallet app to target alphanet2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     implementation "org.jetbrains.anko:anko-commons:$anko_version"
 
     // Radix DLT client library
-    implementation 'com.radixdlt:radixdlt-kotlin:0.11.6'
+    implementation 'com.radixdlt:radixdlt-kotlin:0.11.7'
 
     def androidx_version = "1.0.0"
     implementation "androidx.legacy:legacy-support-v4:$androidx_version"

--- a/app/src/main/java/com/radixdlt/android/RadixWalletApplication.kt
+++ b/app/src/main/java/com/radixdlt/android/RadixWalletApplication.kt
@@ -46,7 +46,7 @@ class RadixWalletApplication : Application(), HasActivityInjector, HasSupportFra
         generateEncryptionKey()
 
         AndroidThreeTen.init(this)
-        RadixUniverse.bootstrap(Bootstrap.ALPHANET)
+        RadixUniverse.bootstrap(Bootstrap.ALPHANET2)
 
         densityPixel = dip(250)
     }

--- a/app/src/main/java/com/radixdlt/android/util/Constants.kt
+++ b/app/src/main/java/com/radixdlt/android/util/Constants.kt
@@ -1,4 +1,4 @@
 package com.radixdlt.android.util
 
 const val PREF_SECRET = "secretKey"
-const val FAUCET_ADDRESS = "9he94tVfQGAVr4xoUpG3uJfB2exURExzFV6E7dq4bxUWRbM5Edd" // alphanetwork
+const val FAUCET_ADDRESS = "9ey8A461d9hLUVXh7CgbYhfmqFzjzSBKHvPC8SMjccRDbkTs2aM" // alphanet2


### PR DESCRIPTION
This change includes targeting a different faucet service, while only
one of them (this new one) had some rads to give away. In the future we
should perhaps allow the app to have a fallback option to a secondary
faucet, would the primary be out of money.